### PR TITLE
Modification du lien "Retour à l'accueil"

### DIFF
--- a/mentions_legales.html
+++ b/mentions_legales.html
@@ -200,7 +200,7 @@
 
             Pour toute demande liée aux données personnelles, nous vous demandons de nous contacter <a href="mailto:trackwat@gmail.com">par mail</a>.
             <br><br>
-            <a href="https://trackwatt.fr">< Retour à l'accueil</a>
+            <a href="https://trackmywatt.fr">< Retour à l'accueil</a>
       </div>
 
     </main>


### PR DESCRIPTION
Le lien actuel étant trackwatt.fr, au lieu de trackmywatt.fr.