### PR TITLE
Meilleure visualisation annotation graph "pic mensuel de puissance"

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -262,7 +262,8 @@ function chart_consumption_max_daily(data){
       arrowhead: 4,
       yshift: 0,
       ax:0,
-      font: {color: "rgb(0, 0, 0)"}
+      font: {color: "rgb(0, 0, 0)"},
+      bgcolor: "rgba(245, 245, 250, 0.8)",
     },]
 
   var data_chart = [

--- a/scripts.js
+++ b/scripts.js
@@ -260,10 +260,11 @@ function chart_consumption_max_daily(data){
       text:  data.max_monthly_power_consumption.at(0).toLocaleString("FR") + ' MW max sur<br>le mois actuel',
       showarrow: true,
       arrowhead: 4,
-      yshift: 0,
+      yshift: 2,
       ax:0,
+      ay: -125,
+      align: "right",
       font: {color: "rgb(0, 0, 0)"},
-      bgcolor: "rgba(245, 245, 250, 0.8)",
     },]
 
   var data_chart = [


### PR DESCRIPTION
Ajout d'un arrière-plan pour l'annotation du graphique "Pic mensuel de puissance" pour une meilleure lisibilité.


**Note**: Je n'ai jamais fait de javascript avant, je souhaitais juste remonter le texte dans la partie blanche. Mais je n'ai pas réussi à augmenter la longueur de la flèche.
Si quelqu'un a la réponse de comment changer cela, ce serait peut-être une meilleure solution. 😃 

En attendant, je propose un simple arrière-plan.